### PR TITLE
Avoid digit changes on speed slider adjustment

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,10 +35,7 @@ if (speedSlider && speedValue) {
     // Linear interpolation, inverted
     speedFactor = minFactor + (max - val) * (maxFactor - minFactor) / (max - min);
     speedValue.textContent = `${val}ms`;
-    if (running) {
-      stopAll();
-      startAll();
-    }
+    // Existing loops will pick up the new delay on their next tick
   }
   speedSlider.addEventListener('input', function() {
     updateSpeedFactor(this.value);


### PR DESCRIPTION
## Summary
- remove restart logic from `updateSpeedFactor`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5362c7083329b6bc7c6909c00a5